### PR TITLE
Recipe : nettoyer otherfindaid list

### DIFF
--- a/cypress/fixtures/example-ffas.xml
+++ b/cypress/fixtures/example-ffas.xml
@@ -62,6 +62,20 @@
       première instance de Encoreunecommune (1791-1905).</p>
     </relatedmaterial>
 
+    <otherfindaid>
+      <head>test</head>
+      <list>
+        <item>A</item>
+        <item>B</item>
+      </list>
+      <list>
+        <item><archref
+            data-cy="otherfindaid-child"
+            href="FRADXXX_.pdf"
+          /></item>
+      </list>
+    </otherfindaid>
+
     <dsc type="in-depth">
       <c id="tt1-1" data-cy="c-branche">
         <!--titre niveau 1-->

--- a/cypress/integration/recipes.js
+++ b/cypress/integration/recipes.js
@@ -174,4 +174,29 @@ describe("Recipe unit test", function () {
         expect(xpathFilter(doc, elem, 'daoloc[@role="exception"]')[0].getAttribute("href")).to.be.equal("0000");
         expect(xpathFilter(doc, elem, 'daoloc[@role="extension"]')[0].getAttribute("href")).to.be.equal("jpg");
     });
+    it("nettoyerOtherfindaidList", function () {
+        const xpathExpr = '//otherfindaid/list';
+        const xpathExpr2 = '//archref[@data-cy="otherfindaid-child"]';
+        const xpathExpr3 = '//otherfindaid/text()';
+        const matchesBefore = xpathFilter(doc, xpathExpr);
+        const matchesBefore2 = xpathFilter(doc, xpathExpr2);
+        const matchesBefore3 = xpathFilter(doc, xpathExpr3).filter(node => {
+            return node.data.trim() !== "";
+        });
+        expect(matchesBefore.length).to.be.equal(2);
+        expect(matchesBefore2.length).to.be.equal(1);
+        expect(matchesBefore3.length).to.be.equal(0);
+
+        doc = recipes.nettoyer_otherfindaid_list()(doc);
+
+        const matchesAfter = xpathFilter(doc, xpathExpr);
+        const matchesAfter2 = xpathFilter(doc, xpathExpr2);
+        const matchesAfter3 = xpathFilter(doc, xpathExpr3).filter(node => {
+            return node.data.trim() !== "";
+        });
+        expect(matchesAfter.length).to.be.equal(0);
+        expect(matchesAfter2.length).to.be.equal(1);
+        expect(matchesAfter3.length).to.be.equal(2);
+        expect(matchesAfter3[0].data).to.be.equal("A");
+    });
 });

--- a/src/lib/recipes/index.js
+++ b/src/lib/recipes/index.js
@@ -65,6 +65,7 @@ import ajouterAltRenderForce from "./individual-recipes/ajouter-alt-render-force
 import ajouterTypologieArticle from "./individual-recipes/ajouter-typologie-article.js";
 import ajouterAccessRestrictLigeo from "./individual-recipes/ajouter-accessrestrict-ligeo.js";
 import transformeDaogrpLigeo from "./individual-recipes/transforme-daogrp-ligeo.js";
+import nettoyerOtherfindaidList from "./individual-recipes/nettoyer-otherfindaid-list.js";
 
 /**
  * Returns an array of 'simple' recipes creators : functions that create functions that take a single DOM `Document` as argument and returns
@@ -132,6 +133,7 @@ export const getRecipes = () => {
         { key: "ajouter_typologie_article", fn: ajouterTypologieArticle },
         { key: "ajouter_accessrestrict_ligeo", fn: ajouterAccessRestrictLigeo },
         { key: "transforme_daogrp_ligeo", fn: transformeDaogrpLigeo },
+        { key: "nettoyer_otherfindaid_list", fn: nettoyerOtherfindaidList },
     ];
 };
 

--- a/src/lib/recipes/individual-recipes/nettoyer-otherfindaid-list.js
+++ b/src/lib/recipes/individual-recipes/nettoyer-otherfindaid-list.js
@@ -1,0 +1,23 @@
+//@flow
+import { xpathFilter } from "../../xml.js";
+import { each } from "../utils.js";
+/**
+ * Remove `//otherfindaid/list/item` tags but keep their content
+ */
+export default () => (doc: Document): Document => {
+    const items = xpathFilter(doc, "//otherfindaid/list/item");
+    keepChildrenAndRemove(items);
+    const lists = xpathFilter(doc, "//otherfindaid/list");
+    keepChildrenAndRemove(lists);
+    return doc;
+};
+
+function keepChildrenAndRemove(items: Array<Element>) {
+    each(items, (element) => {
+        if (element.childNodes) {
+            element.replaceWith(...element.childNodes);
+        } else {
+            element.remove();
+        }
+    });
+}

--- a/src/lib/recipes/recipes-lib.js
+++ b/src/lib/recipes/recipes-lib.js
@@ -246,6 +246,13 @@ const availables: Array<[string, RecipeInfo]> = [
         },
     ],
     [
+        "nettoyer_otherfindaid_list",
+        {
+            label: "Enlever les otherfindaid>list>item mais conserver leur contenu",
+            category: "Suppressions",
+        },
+    ],
+    [
         "corriger_deplacer_genreform",
         {
             label: "Déplacer certains genreform dans physdesc",


### PR DESCRIPTION
Pour la valeur xml initiale
```
<otherfindaid>
	<head>test</head>
	test2
	<list>
		<item>A</item>
		<item>B</item>
	</list>
	<list>
		<item>
			<archref href="C" />
		</item>
	</list>
</otherfindaid>
```
Le résultat devrait être
```
<otherfindaid>
	<head>test</head>
	test2
	A
	B
	<archref href="C" />
</otherfindaid>
```